### PR TITLE
Add jcenter to buildScript repositories

### DIFF
--- a/BasicHistoryApi/build.gradle
+++ b/BasicHistoryApi/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'

--- a/BasicHistorySessions/build.gradle
+++ b/BasicHistorySessions/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'

--- a/BasicRecordingApi/build.gradle
+++ b/BasicRecordingApi/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'

--- a/BasicSensorsApi/build.gradle
+++ b/BasicSensorsApi/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'

--- a/StepCounter/build.gradle
+++ b/StepCounter/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'


### PR DESCRIPTION
could not resolve dependencies on fresh close/checkout due to missing jcenter/mavenCentral.